### PR TITLE
Handle shell integration-related user vars in the "user-var-changed" event

### DIFF
--- a/lua/wezterm-config/init.lua
+++ b/lua/wezterm-config/init.lua
@@ -66,7 +66,8 @@ function M.set_wezterm_user_var(name, value)
         --     value = value,
         -- })
         value_tbl = vim.json.encode(value)
-    elseif value_type == 'table' then
+    -- elseif value_type == 'table' then
+    else
         -- NOTE: remember that config.background is like { { source = { File = '...' } }, ... }
         -- looks like the outermost pair(s) of curly braces get converted/interpreted as array []
         -- by vim.json.encode()

--- a/lua/wezterm-config/init.lua
+++ b/lua/wezterm-config/init.lua
@@ -62,15 +62,17 @@ function M.set_wezterm_user_var(name, value)
     local value_tbl
     if value_type == 'boolean' or value_type == 'number' then
         value = tostring(value)
-        value_tbl = vim.json.encode({
-            value = value,
-        })
+        -- value_tbl = vim.json.encode({
+        --     value = value,
+        -- })
+        value_tbl = vim.json.encode(value)
     elseif value_type == 'table' then
         -- NOTE: remember that config.background is like { { source = { File = '...' } }, ... }
         -- looks like the outermost pair(s) of curly braces get converted/interpreted as array []
         -- by vim.json.encode()
         -- actually it seems to work without the gsub...
-        value_tbl = vim.json.encode({ value = value })
+        -- value_tbl = vim.json.encode({ value = value })
+        value_tbl = vim.json.encode(value)
         -- value = string.gsub(value, '[%[%]]', '')
     end
 

--- a/lua/wezterm-config/init.lua
+++ b/lua/wezterm-config/init.lua
@@ -74,8 +74,6 @@ function M.set_wezterm_user_var(name, value)
         -- value = string.gsub(value, '[%[%]]', '')
     end
 
-    P(value_tbl)
-
     -- NOTE: v0.10 adds vim.version.ge() and vim.version.le() so shouldn't use it yet since v0.10 isn't out
     -- NOTE: v0.10 renames vim.loop to vim.uv and vim.base64 module is added
     -- https://neovim.io/doc/user/news.html

--- a/lua/wezterm-config/init.lua
+++ b/lua/wezterm-config/init.lua
@@ -59,22 +59,14 @@ function M.set_wezterm_user_var(name, value)
     end
 
     local value_type = type(value)
-    local value_tbl
+    local value_out
     if value_type == 'boolean' or value_type == 'number' then
-        value = tostring(value)
-        -- value_tbl = vim.json.encode({
-        --     value = value,
-        -- })
-        value_tbl = vim.json.encode(value)
-    -- elseif value_type == 'table' then
+        value_out = vim.json.encode(tostring(value))
     else
         -- NOTE: remember that config.background is like { { source = { File = '...' } }, ... }
         -- looks like the outermost pair(s) of curly braces get converted/interpreted as array []
         -- by vim.json.encode()
-        -- actually it seems to work without the gsub...
-        -- value_tbl = vim.json.encode({ value = value })
-        value_tbl = vim.json.encode(value)
-        -- value = string.gsub(value, '[%[%]]', '')
+        value_out = vim.json.encode(value)
     end
 
     -- NOTE: v0.10 adds vim.version.ge() and vim.version.le() so shouldn't use it yet since v0.10 isn't out
@@ -112,7 +104,7 @@ function M.set_wezterm_user_var(name, value)
     end
 
     local stdout = uv.new_tty(1, false)
-    local value_b64_enc = base64.encode(value_tbl)
+    local value_b64_enc = base64.encode(value_out)
 
     -- people have asked Wez about stuff like this before, to which he's linked
     -- https://wezfurlong.org/wezterm/recipes/passing-data.html

--- a/lua/wezterm-config/init.lua
+++ b/lua/wezterm-config/init.lua
@@ -59,16 +59,22 @@ function M.set_wezterm_user_var(name, value)
     end
 
     local value_type = type(value)
+    local value_tbl
     if value_type == 'boolean' or value_type == 'number' then
         value = tostring(value)
+        value_tbl = vim.json.encode({
+            value = value,
+        })
     elseif value_type == 'table' then
         -- NOTE: remember that config.background is like { { source = { File = '...' } }, ... }
         -- looks like the outermost pair(s) of curly braces get converted/interpreted as array []
         -- by vim.json.encode()
         -- actually it seems to work without the gsub...
-        value = vim.json.encode(value)
+        value_tbl = vim.json.encode({ value = value })
         -- value = string.gsub(value, '[%[%]]', '')
     end
+
+    P(value_tbl)
 
     -- NOTE: v0.10 adds vim.version.ge() and vim.version.le() so shouldn't use it yet since v0.10 isn't out
     -- NOTE: v0.10 renames vim.loop to vim.uv and vim.base64 module is added
@@ -105,7 +111,7 @@ function M.set_wezterm_user_var(name, value)
     end
 
     local stdout = uv.new_tty(1, false)
-    local value_b64_enc = base64.encode(value)
+    local value_b64_enc = base64.encode(value_tbl)
 
     -- people have asked Wez about stuff like this before, to which he's linked
     -- https://wezfurlong.org/wezterm/recipes/passing-data.html

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -11,7 +11,7 @@ local M = {}
 
 ---@param var string
 ---@return boolean
-function M.is_shell_integ_user_var(var)
+local function is_shell_integ_user_var(var)
     local shell_integ_user_vars = {
         'WEZTERM_PROG',
         'WEZTERM_USER',
@@ -35,7 +35,7 @@ end
 ---@param value string
 ---@return table
 function M.override_user_var(overrides, name, value)
-    if not M.is_shell_integ_user_var(name) then
+    if not is_shell_integ_user_var(name) then
         -- returns tbl if successfully parsed
         -- otherwise it returns 1 (?) so I guess an error code or at least
         -- something with type == 'number'

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -39,13 +39,7 @@ function M.override_user_var(overrides, name, value)
         -- returns tbl if successfully parsed
         -- otherwise it returns 1 (?) so I guess an error code or at least
         -- something with type == 'number'
-
-        -- local ok, parsed_val = pcall(wezterm.json_parse, value)
         local parsed_val = wezterm.json_parse(value)
-        -- if type(parsed_val) == 'table' then
-        --     parsed_val = parsed_val.value
-        -- end
-
         if type(parsed_val) == 'table' then
             overrides[name] = parsed_val
         else

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -35,27 +35,29 @@ end
 ---@param value string
 ---@return table
 function M.override_user_var(overrides, name, value)
-    -- returns tbl if successfully parsed
-    -- otherwise it returns 1 (?) so I guess an error code or at least
-    -- something with type == 'number'
+    if not M.is_shell_integ_user_var(name) then
+        -- returns tbl if successfully parsed
+        -- otherwise it returns 1 (?) so I guess an error code or at least
+        -- something with type == 'number'
 
-    -- local ok, parsed_val = pcall(wezterm.json_parse, value)
-    local parsed_val = wezterm.json_parse(value)
-    -- if type(parsed_val) == 'table' then
-    --     parsed_val = parsed_val.value
-    -- end
+        -- local ok, parsed_val = pcall(wezterm.json_parse, value)
+        local parsed_val = wezterm.json_parse(value)
+        -- if type(parsed_val) == 'table' then
+        --     parsed_val = parsed_val.value
+        -- end
 
-    if type(parsed_val) == 'table' then
-        overrides[name] = parsed_val
-    else
-        if parsed_val == 'true' or parsed_val == 'false' then
-            -- convert to bool
-            parsed_val = parsed_val == 'true'
-        elseif string.match(parsed_val, '^%d*%.?%d+$') then
-            -- convert to number
-            parsed_val = tonumber(parsed_val)
+        if type(parsed_val) == 'table' then
+            overrides[name] = parsed_val
+        else
+            if parsed_val == 'true' or parsed_val == 'false' then
+                -- convert to bool
+                parsed_val = parsed_val == 'true'
+            elseif string.match(parsed_val, '^%d*%.?%d+$') then
+                -- convert to number
+                parsed_val = tonumber(parsed_val)
+            end
+            overrides[name] = parsed_val
         end
-        overrides[name] = parsed_val
     end
     return overrides
 end

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -42,7 +42,11 @@ function M.override_user_var(overrides, name, value)
     -- local ok, parsed_val = pcall(wezterm.json_parse, value)
     local parsed_val = wezterm.json_parse(value)
     if type(parsed_val) == 'table' then
-        overrides[name] = parsed_val.value
+        parsed_val = parsed_val.value
+    end
+
+    if type(parsed_val) == 'table' then
+        overrides[name] = parsed_val
     else
         if parsed_val == 'true' or parsed_val == 'false' then
             -- convert to bool

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -41,9 +41,9 @@ function M.override_user_var(overrides, name, value)
 
     -- local ok, parsed_val = pcall(wezterm.json_parse, value)
     local parsed_val = wezterm.json_parse(value)
-    if type(parsed_val) == 'table' then
-        parsed_val = parsed_val.value
-    end
+    -- if type(parsed_val) == 'table' then
+    --     parsed_val = parsed_val.value
+    -- end
 
     if type(parsed_val) == 'table' then
         overrides[name] = parsed_val

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -9,6 +9,23 @@ end
 local wezterm = require('wezterm')
 local M = {}
 
+---@param var string
+---@return boolean
+function M.is_shell_integ_user_var(var)
+    local shell_integ_user_vars = {
+        'WEZTERM_PROG',
+        'WEZTERM_USER',
+        'WEZTERM_HOST',
+        'WEZTERM_IN_TMUX',
+    }
+    for _, val in ipairs(shell_integ_user_vars) do
+        if val == var then
+            return true
+        end
+    end
+    return false
+end
+
 ---Interpret the Wezterm user var that is passed in and
 ---make the appropriate changes to the given overrides table;
 ---for use within a callback function in Wezterm config
@@ -21,18 +38,20 @@ function M.override_user_var(overrides, name, value)
     -- returns tbl if successfully parsed
     -- otherwise it returns 1 (?) so I guess an error code or at least
     -- something with type == 'number'
+
+    -- local ok, parsed_val = pcall(wezterm.json_parse, value)
     local parsed_val = wezterm.json_parse(value)
     if type(parsed_val) == 'table' then
-        overrides[name] = parsed_val
+        overrides[name] = parsed_val.value
     else
-        if value == 'true' or value == 'false' then
+        if parsed_val == 'true' or parsed_val == 'false' then
             -- convert to bool
-            value = value == 'true'
-        elseif string.match(value, '^%d*%.?%d+$') then
+            parsed_val = parsed_val == 'true'
+        elseif string.match(parsed_val, '^%d*%.?%d+$') then
             -- convert to number
-            value = tonumber(value)
+            parsed_val = tonumber(parsed_val)
         end
-        overrides[name] = value
+        overrides[name] = parsed_val
     end
     return overrides
 end


### PR DESCRIPTION
User vars described [here](https://wezfurlong.org/wezterm/shell-integration.html) appear to cause issues with the plugin when using `wezterm.config_builder()`. Seems like the issue is that calling `override_user_var()` on the "user-var-changed" event without excluding such special user vars can cause errors because the plugin doesn't know better and passes them to the Wezterm config as if they are config fields. They are not so an error occurs.